### PR TITLE
Add root path check in exp13 Sweep

### DIFF
--- a/Experiments/exp13/Sweep.py
+++ b/Experiments/exp13/Sweep.py
@@ -1,4 +1,23 @@
 #!/usr/bin/env python3
+"""Parameter sweep launcher for experiment 13.
+
+This script was copied from an older repository where ``tetris_ballistic`` was
+already installed as a package.  When executed directly from this repository the
+package might not be on ``PYTHONPATH`` which leads to ``ModuleNotFoundError``.
+
+The small block below adds the project root (two directories up from this file)
+to ``sys.path`` so that ``tetris_ballistic`` can be imported without requiring a
+prior ``pip install -e .`` step.
+"""
+
+from pathlib import Path
+import sys
+
+# Add the project root to Python's search path if needed
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
+
 from tetris_ballistic.sweep_parameters import sweep_parameters as sp
 from tetris_ballistic.data_analysis_utilities import insert_joblibs
 


### PR DESCRIPTION
## Summary
- update `Experiments/exp13/Sweep.py` to ensure `tetris_ballistic` package can be
  imported when run directly
- add explanation and path injection at runtime

## Testing
- `pytest -q` *(fails: 18 passed, 2 skipped, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68425c916fa483279dbd188417493c26